### PR TITLE
Feat/user controller

### DIFF
--- a/api/src/main/java/com/api/controller/ApiResult.java
+++ b/api/src/main/java/com/api/controller/ApiResult.java
@@ -12,7 +12,7 @@ public class ApiResult<T> {
 
     private ApiError error;
 
-    public ApiResult(boolean success, T response, ApiError error) {
+    private ApiResult(boolean success, T response, ApiError error) {
         this.success = success;
         this.response = response;
         this.error = error;

--- a/api/src/main/java/com/api/controller/user/JoinRequest.java
+++ b/api/src/main/java/com/api/controller/user/JoinRequest.java
@@ -8,15 +8,15 @@ public class JoinRequest {
 
     public String name;
 
-    private String credential;
+    private String credentials;
 
     private JoinRequest() {
     }
 
-    public JoinRequest(String principal, String name, String credential) {
+    public JoinRequest(String principal, String name, String credentials) {
         this.principal = principal;
         this.name = name;
-        this.credential = credential;
+        this.credentials = credentials;
     }
 
     public String getPrincipal() {
@@ -27,8 +27,8 @@ public class JoinRequest {
         return name;
     }
 
-    public String getCredential() {
-        return credential;
+    public String getCredentials() {
+        return credentials;
     }
 
     @Override
@@ -36,7 +36,7 @@ public class JoinRequest {
         return new StringJoiner(", ", JoinRequest.class.getSimpleName() + "[", "]")
                 .add("principal='" + principal + "'")
                 .add("name='" + name + "'")
-                .add("credential='" + credential + "'")
+                .add("credentials='" + credentials + "'")
                 .toString();
     }
 }

--- a/api/src/main/java/com/api/controller/user/JoinRequest.java
+++ b/api/src/main/java/com/api/controller/user/JoinRequest.java
@@ -10,7 +10,7 @@ public class JoinRequest {
 
     private String credential;
 
-    public JoinRequest() {
+    private JoinRequest() {
     }
 
     public JoinRequest(String principal, String name, String credential) {
@@ -23,24 +23,12 @@ public class JoinRequest {
         return principal;
     }
 
-    public void setPrincipal(String principal) {
-        this.principal = principal;
-    }
-
     public String getName() {
         return name;
     }
 
-    public void setName(String name) {
-        this.name = name;
-    }
-
     public String getCredential() {
         return credential;
-    }
-
-    public void setCredential(String credential) {
-        this.credential = credential;
     }
 
     @Override

--- a/api/src/main/java/com/api/controller/user/UserController.java
+++ b/api/src/main/java/com/api/controller/user/UserController.java
@@ -9,8 +9,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.NoSuchElementException;
-
 import static com.api.controller.ApiResult.OK;
 
 @RestController
@@ -59,7 +57,7 @@ public class UserController {
     @PostMapping("join")
     public ApiResult<UserDto> join(@RequestBody JoinRequest request) {
         return OK(
-            new UserDto(userService.join(request.getPrincipal(), request.getName(), request.getCredential()))
+            new UserDto(userService.join(request.getPrincipal(), request.getName(), request.getCredentials()))
         );
     }
 }

--- a/api/src/main/java/com/api/repository/user/UserRepositoryImpl.java
+++ b/api/src/main/java/com/api/repository/user/UserRepositoryImpl.java
@@ -1,10 +1,13 @@
 package com.api.repository.user;
 
 import com.api.model.user.User;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public class UserRepositoryImpl implements UserRepository {
+
     @Override
     public User insert(User user) {
         return null;

--- a/api/src/main/java/com/api/repository/user/UserRepositoryImpl.java
+++ b/api/src/main/java/com/api/repository/user/UserRepositoryImpl.java
@@ -1,0 +1,17 @@
+package com.api.repository.user;
+
+import com.api.model.user.User;
+
+import java.util.Optional;
+
+public class UserRepositoryImpl implements UserRepository {
+    @Override
+    public User insert(User user) {
+        return null;
+    }
+
+    @Override
+    public Optional<User> findById(Long userId) {
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
**1. ApiResult 생성자 public -> private 변경**
- static 메서드로 ApiResult 객체를 생성하기 때문에 외부에서 생성자 접근 불가하게 변경

**2. JoinRequest 기본 생성자 public -> private 변경**
- ObjectMapper 를 위한 기본 생성자는 reflection 이 기본 생성자를 통해 객체를 생성하기 때문이고, reflection 은 접근 제어자에 영향을 받지 않기 때문에 빈 객체를 생성하지 못하도록 private 로 변경
- (질문) default 나 protected 로 변경한다면 문제가 생기는지 궁금합니다.

**3. JoinRequest setter 제거**
- `@RequestBody` 는 post 요청을 받는 경우 ObjectMapper 를 사용하기 때문에 setter 가 필요하지 않다.

**기타**
- UserRepositoryImpl.java 빈 메소드 생성
- 변수명 변경 (credential -> credentials) 일반적으로 복수형으로 쓴다고 해서 수정합니다. 🙂